### PR TITLE
Modified Dockerfile, resulting image is ca. 20 GB smaller

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+# lanai
+
+* interpreter: toy interpreter
+* llvm: dockerfile and shellscript to run llvm/clang with lanai support

--- a/README.md
+++ b/README.md
@@ -38,4 +38,3 @@ have multiplication opcodes, but that is mostly irrelevant for
 Truebit because of its logarithmic scalability - it is possible to
 verify 1000000 computational steps in about five rounds and
 for 100000000 steps it takes eight rounds. 
-

--- a/llvm/Dockerfile
+++ b/llvm/Dockerfile
@@ -1,14 +1,10 @@
 FROM ubuntu:xenial
 
-RUN apt-get update && apt-get -y install cmake git build-essential vim python clang
-RUN apt-get -y remove gcc g++
+RUN apt-get update && apt-get -y install cmake git build-essential vim python clang && apt-get -y remove gcc g++
 RUN mkdir /src
-RUN cd /src && git clone http://llvm.org/git/llvm.git
-RUN cd /src/llvm/tools && git clone http://llvm.org/git/clang.git
+RUN cd /src && git clone http://llvm.org/git/llvm.git && cd /src/llvm/tools && git clone http://llvm.org/git/clang.git
 RUN mkdir /src/llvm/build 
 RUN sed -i -e s/Hexagon/Lanai/ /src/llvm/CMakeLists.txt
-RUN cd /src/llvm/build && cmake -DLLVM_TARGETS_TO_BUILD="X86;Lanai" ..
-RUN cd /src/llvm/build && make -j 3
-RUN cd /src/llvm/build && make install
+RUN cd /src/llvm/build && cmake -DLLVM_TARGETS_TO_BUILD="X86;Lanai" .. && cd /src/llvm/build && make -j 3 && cd /src/llvm/build && make install && rm -Rf /src
 
 WORKDIR /mnt/

--- a/llvm/Dockerfile
+++ b/llvm/Dockerfile
@@ -4,7 +4,9 @@ RUN apt-get update && apt-get -y install cmake git build-essential vim python cl
 RUN apt-get -y remove gcc g++
 RUN mkdir /src
 RUN cd /src && git clone http://llvm.org/git/llvm.git
+RUN cd /src/llvm && git checkout stable
 RUN cd /src/llvm/tools && git clone http://llvm.org/git/clang.git
+RUN cd /src/llvm/tools/clang && git checkout google/stable
 RUN mkdir /src/llvm/build 
 RUN sed -i -e s/Hexagon/Lanai/ /src/llvm/CMakeLists.txt
 RUN cd /src/llvm/build && cmake -DLLVM_TARGETS_TO_BUILD="X86;Lanai" ..

--- a/llvm/build.sh
+++ b/llvm/build.sh
@@ -2,6 +2,7 @@
 
 set -ev
 
-docker build -t clang-lanai .
-docker run -v $(pwd):/mnt -t clang-lanai clang --target=lanai -S /mnt/example.c
-docker run -v $(pwd):/mnt -t clang-lanai clang --target=lanai -c /mnt/example.c
+#docker build -t step21/clang-lanai-flat .
+docker run -v $(pwd):/mnt -t step21/clang-lanai-flat clang --target=lanai -S /mnt/"$@"
+docker run -v $(pwd):/mnt -t step21/clang-lanai-flat clang --target=lanai -c /mnt/"$@"
+


### PR DESCRIPTION
I had some space issues with frequent docker errors, mostly caused by docker somewhere running out of space and not being honest about it. My resulting image was 37 GB, which is also quite a lot and adds up, especially if you try multiple times and do not clean up docker regularly.
So in this changed file, many commands have been combined so that they count as one layer which should save space and after `make install` the `/src` directory is deleted which saves around 20 GB.
The biggest remaining part is the llvm/clang installation in `/usr/local` which amounts to roughly 15 GB with libraries and headers and everything.